### PR TITLE
fix: update timezone to use local time

### DIFF
--- a/src/config/cron.config.ts
+++ b/src/config/cron.config.ts
@@ -8,20 +8,20 @@ import { budgetService } from '../domains/budget/budget.service';
 let budgetJob: ScheduledTask | undefined;
 
 /**
- * 매월 1일 00:00 UTC에 예산을 자동 생성하도록 예약된 작업을 등록한다.
+ * 매월 1일 00:00 local time에 예산을 자동 생성하도록 예약된 작업을 등록한다.
  *
- * 예약된 실행 시 현재 UTC 기준 연도와 월을 계산하여 `budgetService.seedMonthlyBudgetsFromCriteria`를 호출해 해당 월의 예산을 생성하며, 성공 또는 실패 결과를 콘솔에 기록한다.
+ * 예약된 실행 시 현재 local 기준 연도와 월을 계산하여 `budgetService.seedMonthlyBudgetsFromCriteria`를 호출해 해당 월의 예산을 생성하며, 성공 또는 실패 결과를 콘솔에 기록한다.
  */
 export function startBudgetScheduler() {
   if (budgetJob) return budgetJob;
   budgetJob = cron.schedule(
-    // 매달 1일 00:00 UTC
+    // 매달 1일 00:00 local time
     '0 0 1 * *',
     async () => {
       try {
         const now = new Date();
-        const year = now.getUTCFullYear();
-        const month = now.getUTCMonth() + 1; // 1~12
+        const year = now.getFullYear();
+        const month = now.getMonth() + 1; // 1~12
         await budgetService.seedMonthlyBudgetsFromCriteria(year, month);
         logger.info('[budget] seeded', { year, month });
       } catch (err) {
@@ -30,8 +30,7 @@ export function startBudgetScheduler() {
           err instanceof Error ? { message: err.message, stack: err.stack } : err
         );
       }
-    },
-    { timezone: 'UTC' }
+    }
   );
 
   return budgetJob;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ app.use(express.json());
 
 // 헬스체크 엔드포인트
 app.get('/health', (_req: Request, res: Response) => {
-  res.status(200).json({ status: 'ok', timestamp: new Date().toISOString() });
+  res.status(200).json({ status: 'ok', timestamp: new Date().toLocaleString() });
 });
 
 // 기본 라우트


### PR DESCRIPTION
## 📝 변경사항
- 코드에서 UTC를 기준으로 설정했던 작업들을 로컬 타임을 이용하도록 수정

## 🔨 작업 내용
- [x] 매월 1일 00:00 UTC를 기준으로 설정하던 cron job을 local time을 기준으로 설정하도록 수정
- [x] health check 포인트에서 local time을 출력하도록 수정

## 🧪 테스트 방법
1. health check에 요청을 보내 로컬 타임으로 나오는지 확인
2. cron job의 시간을 짧게 변경하여(10초) 로그에서 시간대가 local로 나오는지 확인

## 🛠️ 테스트 흐름
- 단일 API 조회 및 log 확인

## 📸 스크린샷 (UI 변경 시)
 - 해당사항 없음

## ✅ 체크리스트
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 주요 로직에 주석을 작성했습니다
- [ ] 테스트 코드를 작성했습니다
- [ ] 문서를 업데이트했습니다 (필요 시)
- [x] 이슈를 연결했습니다

## 🔗 관련 이슈

Closes #48


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 실행 중인 예산 스케줄러를 수동으로 중지할 수 있는 새로운 기능이 추가되었습니다.

* **개선 사항**
  * 월간 예산 동기화 작업이 UTC 시간 대신 시스템의 로컬 시간을 기준으로 실행되며, 매월 1일 자정에 수행됩니다.
  * 상태 확인 엔드포인트의 응답에 포함된 타임스탐프 형식이 로컬 형식으로 변경되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->