### PR TITLE
fix: update log setting to use UTC

### DIFF
--- a/src/common/utils/logger.util.ts
+++ b/src/common/utils/logger.util.ts
@@ -35,7 +35,7 @@ const logFormat = format.printf((info: TransformableInfo) => {
 
 const logger: Logger = createLogger({
   level: isProd ? 'info' : 'debug',
-  format: format.combine(format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }), logFormat),
+  format: format.combine(format.timestamp({ format: () => new Date().toISOString() }), logFormat),
   transports: [
     // 일반 logging
     new DailyRotateFile({
@@ -45,6 +45,7 @@ const logger: Logger = createLogger({
       maxFiles: '30d',
       zippedArchive: true,
       auditFile: auditFile('combined'),
+      utc: true,
     }),
     // error logging
     new DailyRotateFile({
@@ -55,6 +56,7 @@ const logger: Logger = createLogger({
       maxFiles: '30d',
       zippedArchive: true,
       auditFile: auditFile('error'),
+      utc: true,
     }),
   ],
   // 예외 처리 logging
@@ -66,6 +68,7 @@ const logger: Logger = createLogger({
       maxFiles: '30d',
       zippedArchive: true,
       auditFile: auditFile('exception'),
+      utc: true,
     }),
   ],
   // 처리되지 않은 Promise rejection logging
@@ -77,6 +80,7 @@ const logger: Logger = createLogger({
       maxFiles: '30d',
       zippedArchive: true,
       auditFile: auditFile('rejection'),
+      utc: true,
     }),
   ],
 });


### PR DESCRIPTION
## 📝 변경사항
 - 팀 협의사항에 따라 log 파일들이 UTC을 쓰도록 수정

## 🔨 작업 내용
- [x] winston의 date format을 ISO 형식으로 수정
- [x] winston daily rotate file이 UTC를 기준으로 생성되도록 수정

## 🧪 테스트 방법
1. 로그 결과의 time stamp가 UTC로 나오는 것을 확인

## 🛠️ 테스트 흐름
- 단순 로그 확인

## 📸 스크린샷 (UI 변경 시)
- 해당사항 없음

## ✅ 체크리스트
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 주요 로직에 주석을 작성했습니다
- [ ] 테스트 코드를 작성했습니다
- [ ] 문서를 업데이트했습니다 (필요 시)
- [x] 이슈를 연결했습니다

## 🔗 관련 이슈

Closes #48 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **작업**
  * 로그 시스템의 타임스탐프 형식을 표준화된 ISO 형식으로 개선했습니다.
  * 로그 파일 로테이션이 UTC 기준으로 동작하도록 변경되어 모든 시간대에서 일관된 로그 관리를 지원합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->