### PR TITLE
fix: update refresh token to use id instead of userId

### DIFF
--- a/src/domains/auth/auth.service.ts
+++ b/src/domains/auth/auth.service.ts
@@ -170,7 +170,7 @@ export const authService = {
     // 4) refresh 토큰 발급 및 해시 저장
     const refreshToken = JwtUtil.generateRefreshToken({
       id: user.id,
-      jti: crypto.randomUUID(),
+      jti: randomUUID(),
     });
     const refreshTokenHash = await argon2.hash(refreshToken);
     await prisma.users.update({ where: { id: user.id }, data: { refreshToken: refreshTokenHash } });
@@ -239,7 +239,7 @@ export const authService = {
     );
     const newRefreshToken = JwtUtil.generateRefreshToken({
       id: user.id,
-      jti: crypto.randomUUID(),
+      jti: randomUUID(),
     });
     const newRefreshHash = await argon2.hash(newRefreshToken);
 


### PR DESCRIPTION
## 📝 변경사항
- userId와 id를 통합하는 과정에서 제대로 수정이 되지 않은 문제 해결

## 🔨 작업 내용
- [x] auth에서 userId가 사용된 곳에서 id를 사용하도록 수정

## 🧪 테스트 방법
- run dev, start를 통해 정상적으로 가동되는지 확인

## 🛠️ 테스트 흐름
- 별다른 오류없이 실행되는지 단순 확인

## 📸 스크린샷 (UI 변경 시)
- 해당사항 없음

## ✅ 체크리스트

- [x] 코드 스타일 가이드를 준수했습니다
- [x] 주요 로직에 주석을 작성했습니다
- [ ] 테스트 코드를 작성했습니다
- [ ] 문서를 업데이트했습니다 (필요 시)
- [x] 이슈를 연결했습니다

## 🔗 관련 이슈
Closes #73 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 회원가입 흐름에서 새로고침 토큰 페이로드의 필드명을 업데이트했습니다. 토큰 생성, 해싱 및 저장 동작은 변경되지 않았습니다.
  * 로그인 및 토큰 갱신 흐름에서 새로고침 토큰의 식별자 생성 방식이 업데이트되어 일관성이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->