### PR TITLE
feat: add purchase request detail retrieval API for admin

### DIFF
--- a/http/purchase/intellij/getPurchaseRequestDetail.http
+++ b/http/purchase/intellij/getPurchaseRequestDetail.http
@@ -1,0 +1,24 @@
+### 로그인 (먼저 이것을 실행하세요!)
+# @name login
+POST http://localhost:4000/api/v1/auth/login
+Content-Type: application/json
+
+{
+    "email": "manager@test.com",
+    "password": "testM1234!"
+}
+
+> {%
+    client.global.set("token", response.body.data.accessToken);
+%}
+
+###
+
+
+###
+# @name getPurchaseRequestDetail - 구매 요청 상세 조회
+# 구매 요청 ID를 실제 UUID로 교체해야 합니다
+GET http://localhost:4000/api/v1/purchase/admin/getPurchaseRequestDetail/019b97d0-f954-7b91-af1d-77fe04495a95
+Authorization: Bearer {{token}}
+
+###

--- a/http/purchase/vscode/getPurchaseRequestDetail.http
+++ b/http/purchase/vscode/getPurchaseRequestDetail.http
@@ -1,0 +1,30 @@
+### 로그인 (먼저 이것을 실행하세요!)
+# @name login
+POST http://localhost:4000/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "manager@test.com",
+  "password": "testM1234!"
+}
+
+# VSCode 사용 시:
+# 1. 위 요청을 실행한 후 응답에서 accessToken 값을 복사하세요
+# 2. 아래 @token 변수에 토큰을 붙여넣거나
+# 3. http-client.env.json 파일에 token 값을 설정하세요
+
+###
+
+# 토큰을 여기에 설정하거나 http-client.env.json 파일을 사용하세요
+@token = YOUR_ACCESS_TOKEN_HERE
+
+###
+
+
+###
+# @name getPurchaseRequestDetail - 구매 요청 상세 조회
+# 구매 요청 ID를 실제 UUID로 교체해야 합니다
+GET http://localhost:4000/api/v1/purchase/admin/getPurchaseRequestDetail/YOUR_PURCHASE_REQUEST_ID_HERE
+Authorization: Bearer {{token}}
+
+###

--- a/src/domains/purchase/purchase.controller.ts
+++ b/src/domains/purchase/purchase.controller.ts
@@ -166,6 +166,37 @@ export const purchaseController = {
     res.status(HttpStatus.OK).json(result);
   },
 
+  // 💰 [Purchase] 구매 요청 상세 조회 API (관리자)
+  getPurchaseRequestDetail: async (req: AuthenticatedRequest, res: Response) => {
+    // 사용자 정보가 없는 경우
+    if (!req.user) {
+      throw new CustomError(
+        HttpStatus.UNAUTHORIZED,
+        ErrorCodes.AUTH_UNAUTHORIZED,
+        '사용자 정보가 없습니다.'
+      );
+    }
+
+    // 구매 요청 ID가 없는 경우
+    const purchaseRequestId = req.params.id;
+    if (!purchaseRequestId) {
+      throw new CustomError(
+        HttpStatus.BAD_REQUEST,
+        ErrorCodes.GENERAL_INVALID_REQUEST_BODY,
+        '구매 요청 ID가 필요합니다.'
+      );
+    }
+
+    // 서비스 호출
+    const result = await purchaseService.getPurchaseRequestDetail(
+      req.user.companyId,
+      purchaseRequestId
+    );
+
+    // 응답 반환
+    res.status(HttpStatus.OK).json(result);
+  },
+
   // 💰 [Purchase] 구매 요청 조회 API (관리자)
   managePurchaseRequests: async (req: AuthenticatedRequest, res: Response) => {
     // 사용자 정보가 없는 경우

--- a/src/domains/purchase/purchase.router.ts
+++ b/src/domains/purchase/purchase.router.ts
@@ -49,6 +49,16 @@ router.get(
   purchaseController.getMyPurchaseDetail
 );
 
+// 💰 [Purchase] 구매 요청 상세 조회 API (관리자)
+router.get(
+  '/admin/getPurchaseRequestDetail/:id',
+  verifyAccessToken,
+  requireMinRole('MANAGER'),
+  purchaseValidator.validateGetPurchaseRequestDetail,
+  validateRequest,
+  purchaseController.getPurchaseRequestDetail
+);
+
 // 💰 [Purchase] 구매 요청 관리/조회 API (관리자)
 router.get(
   '/admin/managePurchaseRequests',

--- a/src/domains/purchase/purchase.validator.ts
+++ b/src/domains/purchase/purchase.validator.ts
@@ -46,6 +46,16 @@ const validateGetMyPurchaseDetail: ValidationChain[] = [
     .withMessage('구매 요청 ID는 유효한 UUID 형식이어야 합니다.'),
 ];
 
+// 💰 [Purchase] 구매 요청 상세 조회 API (관리자)
+const validateGetPurchaseRequestDetail: ValidationChain[] = [
+  param('id')
+    .notEmpty()
+    .withMessage('구매 요청 ID는 필수입니다.')
+    .bail()
+    .isUUID()
+    .withMessage('구매 요청 ID는 유효한 UUID 형식이어야 합니다.'),
+];
+
 // 💰 [Purchase] 구매 요청 관리/조회 API (관리자)
 const validateManagePurchaseRequests: ValidationChain[] = [
   query('status').optional().isIn(['PENDING', 'APPROVED', 'REJECTED', 'CANCELLED']),
@@ -127,6 +137,7 @@ export const purchaseValidator = {
   validatePurchaseNow,
   validateGetMyPurchase,
   validateGetMyPurchaseDetail,
+  validateGetPurchaseRequestDetail,
   validateManagePurchaseRequests,
   validateApprovePurchaseRequest,
   validateRejectPurchaseRequest,

--- a/src/swagger/purchase.swagger.ts
+++ b/src/swagger/purchase.swagger.ts
@@ -379,9 +379,168 @@
 
 /**
  * @swagger
+ * /api/v1/purchase/admin/getPurchaseRequestDetail/{purchaseRequestId}:
+ *   get:
+ *     summary: 구매 요청 상세 조회 (관리자)
+ *     description: |
+ *       관리자가 모든 구매 요청의 상세 내역을 조회할 수 있습니다.
+ *
+ *       ### 조회 가능한 정보
+ *       - 구매 요청 기본 정보 (ID, 요청일, 승인/반려일, 승인일, 상품 금액, 배송비, 최종 금액, 상태)
+ *       - 요청 메시지 및 반려 사유
+ *       - 구매 항목 목록 (상품명, 수량, 가격 스냅샷, 항목 소계, 이미지, 링크)
+ *       - 요청인 정보 (이름, 이메일)
+ *       - 승인자/반려자 정보 (이름, 이메일)
+ *     tags: [Purchase]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: purchaseRequestId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: 구매 요청 ID
+ *     responses:
+ *       200:
+ *         description: 구매 요청 상세 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       format: uuid
+ *                       description: 구매 요청 ID
+ *                     createdAt:
+ *                       type: string
+ *                       format: date-time
+ *                       description: 요청일
+ *                     updatedAt:
+ *                       type: string
+ *                       format: date-time
+ *                       description: 수정일
+ *                     approvedAt:
+ *                       type: string
+ *                       format: date-time
+ *                       nullable: true
+ *                       description: 승인일 (APPROVED 상태일 때만)
+ *                     itemsTotalPrice:
+ *                       type: number
+ *                       description: 상품 금액 합계 (배송비 제외)
+ *                     shippingFee:
+ *                       type: number
+ *                       description: 배송비
+ *                     finalTotalPrice:
+ *                       type: number
+ *                       description: 최종 금액 (상품 + 배송비)
+ *                     status:
+ *                       type: string
+ *                       enum: [PENDING, APPROVED, REJECTED, CANCELLED]
+ *                       description: 구매 요청 상태
+ *                     requestMessage:
+ *                       type: string
+ *                       nullable: true
+ *                       description: 요청 메시지
+ *                     rejectReason:
+ *                       type: string
+ *                       nullable: true
+ *                       description: 반려 사유
+ *                     purchaseItems:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           id:
+ *                             type: string
+ *                             format: uuid
+ *                             description: 구매 항목 ID
+ *                           quantity:
+ *                             type: integer
+ *                             description: 수량
+ *                           priceSnapshot:
+ *                             type: number
+ *                             description: 구매 시점 가격
+ *                           itemTotal:
+ *                             type: number
+ *                             description: 항목 소계 (수량 × 단가)
+ *                           products:
+ *                             type: object
+ *                             properties:
+ *                               id:
+ *                                 type: integer
+ *                                 description: 상품 ID
+ *                               name:
+ *                                 type: string
+ *                                 description: 상품명
+ *                               image:
+ *                                 type: string
+ *                                 description: 상품 이미지 URL
+ *                               link:
+ *                                 type: string
+ *                                 description: 상품 링크
+ *                     requester:
+ *                       type: object
+ *                       properties:
+ *                         id:
+ *                           type: string
+ *                           format: uuid
+ *                           description: 요청자 ID
+ *                         name:
+ *                           type: string
+ *                           description: 요청자 이름
+ *                         email:
+ *                           type: string
+ *                           description: 요청자 이메일
+ *                     approver:
+ *                       type: object
+ *                       nullable: true
+ *                       properties:
+ *                         id:
+ *                           type: string
+ *                           format: uuid
+ *                           description: 승인자 ID
+ *                         name:
+ *                           type: string
+ *                           description: 승인자 이름
+ *                         email:
+ *                           type: string
+ *                           description: 승인자 이메일
+ *                 message:
+ *                   type: string
+ *                   example: "구매 요청 상세 내역을 조회했습니다."
+ *       401:
+ *         description: 인증 실패
+ *       403:
+ *         description: 권한 없음 (관리자만 접근 가능)
+ *       404:
+ *         description: 구매 요청을 찾을 수 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 message:
+ *                   type: string
+ *                   example: "구매 요청을 찾을 수 없습니다."
+ */
+
+/**
+ * @swagger
  * /api/v1/purchase/admin/managePurchaseRequests:
  *   get:
- *     summary: 구매 요청 확인 (관리자)
+ *     summary: 구매 요청 목록 조회 (관리자)
  *     tags: [Purchase]
  *     security:
  *       - bearerAuth: []


### PR DESCRIPTION
## 📝 변경사항

<!-- 무엇을 변경했는지 간단히 설명해주세요 -->

- 구매 요청 상세 내용을 불러오는 API 작성

## 🔨 작업 내용

- [x] Router, Contoller, Service 수정 및 작성
- [x] Swagger 및 http 파일 수정

## 🧪 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->

1. 주어진 http 파일(getPurchaseRequestDetail.http)을 이용하여, 구체적인 요청 내역이 나오는지 확인

## 🛠️ 테스트 흐름

<!-- 테스트 진행 방법이 어떻게 되는지 간략하게 설명해주세요 -->

사용자 요청 -> router/middleware -> controller -> service -> 사용자 반환

## 📸 스크린샷 (UI 변경 시)

<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요 -->

없습니다.

## ✅ 체크리스트

- [x] 코드 스타일 가이드를 준수했습니다
- [x] 주요 로직에 주석을 작성했습니다
- [ ] 테스트 코드를 작성했습니다
- [x] 문서를 업데이트했습니다 (필요 시)
- [x] 이슈를 연결했습니다

## 🔗 관련 이슈

Closes #111 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관리자용 구매 요청 상세 조회 API 엔드포인트 추가 - 특정 구매 요청의 상세 정보(요청자, 승인자, 구매 항목, 가격 세부사항)를 조회할 수 있습니다. MANAGER 역할 이상의 관리자만 접근 가능합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->