### PR TITLE
fix: remove undefined domain assignment from cookie options

### DIFF
--- a/src/domains/auth/auth.controller.ts
+++ b/src/domains/auth/auth.controller.ts
@@ -100,7 +100,6 @@ const refreshCookieOptions = (maxAgeMs: number): CookieOptions => {
       httpOnly: true,
       secure: true,
       sameSite: 'none',
-      domain: undefined, // 브라우저가 자동으로 설정하도록 함
       path: '/',
       maxAge: maxAgeMs,
     };
@@ -110,7 +109,6 @@ const refreshCookieOptions = (maxAgeMs: number): CookieOptions => {
     httpOnly: true, // 개발 환경에서도 httpOnly 적용
     secure: env.COOKIE_SECURE,
     sameSite: env.COOKIE_SAME_SITE,
-    domain: env.COOKIE_DOMAIN, // 빈 문자열이면 undefined
     path: env.COOKIE_PATH,
     maxAge: maxAgeMs,
   };


### PR DESCRIPTION
## 📝 변경사항

<!-- 무엇을 변경했는지 간단히 설명해주세요 -->

쿠키 옵션에서 도메인 설정을 제거

## 🔨 작업 내용

- [x] 쿠키 옵션에서 도메인 설정을 제거

## 🧪 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->

1. 로그인을 수행하면서, 쿠키에 refreshToken이 저장이 되는지 확인

## 🛠️ 테스트 흐름

<!-- 테스트 진행 방법이 어떻게 되는지 간략하게 설명해주세요 -->

컨트롤러의 일부 코드를 수정하였으므로, 별도의 흐름은 존재하지 않습니다.

## 📸 스크린샷 (UI 변경 시)

<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요 -->

- UI변경은 없으므로, 별도의 사진은 없습니다.

## ✅ 체크리스트

- [x] 코드 스타일 가이드를 준수했습니다
- [x] 주요 로직에 주석을 작성했습니다
- [x] 테스트 코드를 작성했습니다
- [x] 문서를 업데이트했습니다 (필요 시)
- [x] 이슈를 연결했습니다

## 🔗 관련 이슈

Closes #130 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 인증 쿠키 도메인 설정을 조정하여 모든 환경에서 쿠키 처리 방식을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->