### PR TITLE
fix: update default limit for purchase queries to 6

### DIFF
--- a/src/domains/purchase/purchase.service.ts
+++ b/src/domains/purchase/purchase.service.ts
@@ -34,7 +34,7 @@ export const purchaseService = {
   async getAllPurchases(companyId: string, query: GetAllPurchasesQuery) {
     // 기본 값 설정
     const page = query.page || 1;
-    const limit = query.limit || 10;
+    const limit = query.limit || 6;
     const sortBy = query.sortBy || 'createdAt';
     const order = query.order || 'desc';
     // 건너뛸 항목 수 계산
@@ -174,7 +174,7 @@ export const purchaseService = {
   async getMyPurchases(companyId: string, userId: string, query: GetAllPurchasesQuery) {
     // 기본 값 설정
     const page = query.page || 1;
-    const limit = query.limit || 10;
+    const limit = query.limit || 6;
     const sortBy = query.sortBy || 'createdAt';
     const order = query.order || 'desc';
     // 건너뛸 항목 수 계산
@@ -425,7 +425,7 @@ export const purchaseService = {
   ) {
     // 기본 값 설정
     const page = query.page || 1;
-    const limit = query.limit || 10;
+    const limit = query.limit || 6;
     const sortBy = query.sortBy || 'createdAt';
     const order = query.order || 'desc';
     const { status } = query;


### PR DESCRIPTION
## 📝 변경사항

<!-- 무엇을 변경했는지 간단히 설명해주세요 -->

Purchase 도메인의 Pagination에서 한번에 보이는 내역의 갯수를 6개로 기본값 변경

## 🔨 작업 내용

- [x] purchase.servise.ts 수정

## 🧪 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->

1. 별도의 테스트는 진행하지 않았습니다. (단순 상수 변경)

## 🛠️ 테스트 흐름

<!-- 테스트 진행 방법이 어떻게 되는지 간략하게 설명해주세요 -->

- 본 PR은 별도의 흐름이 존재하지 않습니다. (단순 상수 변경)

## 📸 스크린샷 (UI 변경 시)

<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요 -->

- UI변경사항 없음
## ✅ 체크리스트

- [x] 코드 스타일 가이드를 준수했습니다
- [x] 주요 로직에 주석을 작성했습니다
- [x] 테스트 코드를 작성했습니다
- [ ] 문서를 업데이트했습니다 (필요 시)
- [ ] 이슈를 연결했습니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 구매 목록 조회, 내 구매 내역 조회, 구매 요청 관리 등의 기본 페이지네이션 항목 수를 조정했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->